### PR TITLE
Refactor to use default parcel bundler in aio-lib-web

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ governing permissions and limitations under the License.
 const buildWeb = require('./src/build-web')
 const deployWeb = require('./src/deploy-web')
 const undeployWeb = require('./src/undeploy-web')
+const bundle = require('./src/bundle')
 
 /**
  * Adobe I/O app lib web, build / deploy webapps to cdn
@@ -28,6 +29,7 @@ const undeployWeb = require('./src/undeploy-web')
  */
 
 module.exports = {
+  bundle,
   buildWeb,
   deployWeb,
   undeployWeb

--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ const bundle = require('./src/bundle')
 /**
  * @typedef AppLibWeb
  * @type {object}
+ * @property {function(object):Promise<undefined>} bundles - bundles the application's static files
  * @property {function(object):Promise<undefined>} buildWeb - bundles the application's static files
  * @property {function(object):Promise<string>} deployWeb - deploys the static files to a CDN, returns the URL
  * @property {function(object):Promise<undefined>} undeployWeb - removes the deployed static files

--- a/src/build-web.js
+++ b/src/build-web.js
@@ -14,6 +14,9 @@ const fs = require('fs-extra')
 const path = require('path')
 const Bundler = require('parcel-bundler')
 
+/**
+ * @deprecated since 4.1.0 ( January, 2021 ), use `bundle` instead
+ */
 const buildWeb = async (config, log) => {
   if (!config || !config.app || !config.app.hasFrontend) {
     throw new Error('cannot build web, app has no frontend or config is invalid')

--- a/src/bundle.js
+++ b/src/bundle.js
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 
 const Bundler = require('parcel-bundler')
 const aioLogger = require('@adobe/aio-lib-core-logging')('@adobe/aio-lib-web:bundle', { provider: 'debug' })
-
+const fs = require('fs-extra')
 /**
  * @typedef {object} BundleWebObject
  * @property {object} the Parcel bundler object
@@ -40,18 +40,26 @@ const aioLogger = require('@adobe/aio-lib-core-logging')('@adobe/aio-lib-web:bun
 module.exports = async (entryFile, dest, options = {}, log = () => {}) => {
   aioLogger.debug(`bundle options: ${JSON.stringify(options, null, 2)}`)
 
+  if (!entryFile || !fs.existsSync(entryFile)) {
+    throw new Error('cannot build web, entyFile not specified, or does not exist')
+  }
+  if (!dest) {
+    throw new Error('cannot build web, missing destination')
+  }
+
   // set defaults, but allow override by passed in values
   const parcelBundleOptions = {
     cache: true,
     outDir: dest,
     contentHash: true, // false if dev, true if prod ??
-    watch: true, // currently false if dev true if prod,
+    watch: false, // currently false if dev true if prod,
     minify: false,
     logLevel: 1,
     ...options
   }
 
   aioLogger.debug(`bundle bundleOptions: ${JSON.stringify(parcelBundleOptions, null, 2)}`)
+  log(`bundling ${entryFile}`)
   const bundler = new Bundler(entryFile, parcelBundleOptions)
 
   await bundler.bundle()

--- a/src/bundle.js
+++ b/src/bundle.js
@@ -1,0 +1,67 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const Bundler = require('parcel-bundler')
+const aioLogger = require('@adobe/aio-lib-core-logging')('@adobe/aio-lib-web:bundle', { provider: 'debug' })
+
+/**
+ * @typedef {object} BundleWebObject
+ * @property {object} the Parcel bundler object
+ * @property {Function} cleanup callback function to cleanup available resources
+ */
+
+/**
+ * @typedef {object} BundleOptions
+ * @property {boolean} cache
+ * @property {boolean} contentHash
+ * @property {boolean} watch
+ * @property {boolean} minify
+ * @property {number} logLevel
+ */
+
+/**
+ * Bundles the web source via Parcel.
+ *
+ * @param {string} [entryFile] path to entry file to bundle
+ * @param {string} [dest] directory to build to
+ * @param {BundleOptions} [options] the Parcel bundler options
+ * @param {Function} [log] the app logger
+ * @returns {BundleWebObject} the BundleWebObject
+ */
+module.exports = async (entryFile, dest, options = {}, log = () => {}) => {
+  aioLogger.debug(`bundle options: ${JSON.stringify(options, null, 2)}`)
+
+  // set defaults, but allow override by passed in values
+  const parcelBundleOptions = {
+    cache: true,
+    outDir: dest,
+    contentHash: true, // false if dev, true if prod ??
+    watch: true, // currently false if dev true if prod,
+    minify: false,
+    logLevel: 1,
+    ...options
+  }
+
+  aioLogger.debug(`bundle bundleOptions: ${JSON.stringify(parcelBundleOptions, null, 2)}`)
+  const bundler = new Bundler(entryFile, parcelBundleOptions)
+
+  await bundler.bundle()
+  const cleanup = async () => {
+    aioLogger.debug('cleanup bundler...')
+    await bundler.stop()
+  }
+
+  return {
+    bundler,
+    cleanup
+  }
+}

--- a/test/src/bundle.test.js
+++ b/test/src/bundle.test.js
@@ -1,0 +1,91 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const { vol } = global.mockFs()
+const bundle = require('../../src/bundle')
+const fs = require('fs-extra')
+jest.mock('fs-extra')
+
+describe('bundle', () => {
+  beforeEach(() => {
+    // restores all spies
+    fs.readdir.mockReset()
+    jest.restoreAllMocks()
+    global.cleanFs(vol)
+  })
+
+  test('throws if config does not have an app, or frontEnd', async () => {
+    // much of this is actually now the callers responsibility
+    await expect(bundle()).rejects.toThrow('cannot build web')
+    await expect(bundle('dne')).rejects.toThrow('cannot build web')
+    fs.existsSync.mockReturnValue(true)
+    await expect(bundle('exists')).rejects.toThrow('cannot build web, missing')
+  })
+
+  test('build (with and without log function)', async () => {
+    const config = {
+      app: {
+        hasFrontend: true
+      },
+      web: {
+        distProd: 'dist',
+        src: 'fakeDir'
+      }
+    }
+    global.addFakeFiles(vol, 'fakeDir', { 'index.html': '' })
+    fs.readdir.mockReturnValue(['output.html'])
+    const logFunc = jest.fn()
+    await expect(bundle('fakeDir/index.html', config.web.distProd, { }, logFunc)).resolves.toBeTruthy()
+  })
+
+  test('check build options', async () => {
+    global.addFakeFiles(vol, 'fakeDir', { 'index.html': '' })
+    await expect(bundle('fakeDir/index.html', 'distProd')).resolves.toEqual(
+      expect.objectContaining({ bundler: expect.any(Object) }))
+    expect(global._bundler__arguments).toEqual([
+      expect.stringContaining('fakeDir'),
+      expect.objectContaining({
+        cache: true,
+        contentHash: true,
+        logLevel: 1,
+        outDir: 'distProd',
+        watch: false
+      })])
+  })
+
+  test('uses build options', async () => {
+    global.addFakeFiles(vol, 'fakeDir', { 'index.html': '' })
+    await expect(bundle('fakeDir/index.html', 'distProd', { contentHash: false, logLevel: 5 }))
+      .resolves.toEqual(expect.objectContaining({ bundler: expect.any(Object) }))
+    expect(global._bundler__arguments).toEqual([
+      expect.stringContaining('fakeDir'),
+      expect.objectContaining({
+        cache: true,
+        contentHash: false,
+        logLevel: 5,
+        outDir: 'distProd',
+        watch: false
+      })])
+  })
+
+  test('returns {bundle, cleanup}', async () => {
+    global.addFakeFiles(vol, 'fakeDir', { 'index.html': '' })
+
+    const { bundler, cleanup } = await bundle('fakeDir/index.html', 'distProd', { contentHash: false, logLevel: 5 })
+    expect(bundler).toBeDefined()
+    expect(cleanup).toBeDefined()
+    expect(typeof cleanup).toBe('function')
+    bundler.stop = jest.fn()
+    cleanup()
+    expect(bundler.stop).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Description

- replace bundler from aio-cli-plugin-app with functionality here
- allow override of parcel bundler behavior

## Related Issue

adobe/aio-cli-plugin-app/issues/162

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
