### PR TITLE
fix: cache contol for unknown files

### DIFF
--- a/lib/remote-storage.js
+++ b/lib/remote-storage.js
@@ -112,9 +112,11 @@ module.exports = class RemoteStorage {
       Key: urlJoin(prefix, path.basename(file)),
       Body: content,
       ACL: 'public-read',
-      // s3 misses some mime types like for css files
-      ContentType: mimeType,
       CacheControl: cacheControlString
+    }
+    // s3 misses some mime types like for css files
+    if (mimeType) {
+      uploadParams.ContentType = mimeType
     }
     return this.s3.upload(uploadParams).promise()
   }
@@ -165,12 +167,14 @@ module.exports = class RemoteStorage {
 
   /**
     * Get cache control string based on mime type and config
-    * @param {string} mimeType - mime type
+    * @param {string|boolean} mimeType - string if valid mimeType or false for unknown files
     * @param  {Object} appConfig - application config
     */
   _getCacheControlConfig (mimeType, appConfig) {
     const cacheControlStr = 's-maxage=0'
-    if (mimeType === mime.lookup('html')) {
+    if (!mimeType) {
+      return cacheControlStr
+    } else if (mimeType === mime.lookup('html')) {
       return cacheControlStr + ', max-age=' + appConfig.htmlCacheDuration
     } else if (mimeType === mime.lookup('js')) {
       return cacheControlStr + ', max-age=' + appConfig.jsCacheDuration

--- a/test/lib/remote-storage.test.js
+++ b/test/lib/remote-storage.test.js
@@ -157,7 +157,7 @@ describe('RemoteStorage', () => {
   })
 
   test('uploadFile S3#upload with string ContentType', async () => {
-    global.addFakeFiles(vol, 'fakeDir', { 'index.xyz': 'fake content' })
+    global.addFakeFiles(vol, 'fakeDir', { 'index.mst': 'fake content' })
     let uploadParams
     const uploadMock = jest.fn((params) => { uploadParams = params })
     spyS3({
@@ -166,7 +166,7 @@ describe('RemoteStorage', () => {
     const rs = new RemoteStorage(global.fakeTVMResponse)
     const fakeConfig = {}
     await rs.uploadFile('fakeDir/index.mst', 'fakeprefix', fakeConfig)
-    expect(uploadMock).toHaveBeenCalledWith(expect.objectContaining({ Key: 'fakeprefix/index.xyz' }))
+    expect(uploadMock).toHaveBeenCalledWith(expect.objectContaining({ Key: 'fakeprefix/index.mst' }))
     expect(uploadParams.ContentType).toBeUndefined()
   })
 

--- a/test/lib/remote-storage.test.js
+++ b/test/lib/remote-storage.test.js
@@ -140,7 +140,7 @@ describe('RemoteStorage', () => {
     const fakeConfig = {}
     await rs.uploadFile('fakeDir/index.js', 'fakeprefix', fakeConfig)
     const body = Buffer.from('fake content', 'utf8')
-    expect(uploadMock).toHaveBeenCalledWith(expect.objectContaining({ Key: 'fakeprefix/index.js', Body: body }))
+    expect(uploadMock).toHaveBeenCalledWith(expect.objectContaining({ Key: 'fakeprefix/index.js', Body: body, ContentType: 'application/javascript' }))
   })
 
   test('uploadFile should call S3#upload with the correct parameters and slash-prefix', async () => {
@@ -153,7 +153,21 @@ describe('RemoteStorage', () => {
     const fakeConfig = {}
     await rs.uploadFile('fakeDir/index.js', '/slash-prefix', fakeConfig)
     const body = Buffer.from('fake content', 'utf8')
-    expect(uploadMock).toHaveBeenCalledWith(expect.objectContaining({ Key: '/slash-prefix/index.js', Body: body }))
+    expect(uploadMock).toHaveBeenCalledWith(expect.objectContaining({ Key: '/slash-prefix/index.js', Body: body, ContentType: 'application/javascript' }))
+  })
+
+  test('uploadFile S3#upload with string ContentType', async () => {
+    global.addFakeFiles(vol, 'fakeDir', { 'index.xyz': 'fake content' })
+    let uploadParams
+    const uploadMock = jest.fn((params) => { uploadParams = params })
+    spyS3({
+      upload: uploadMock
+    })
+    const rs = new RemoteStorage(global.fakeTVMResponse)
+    const fakeConfig = {}
+    await rs.uploadFile('fakeDir/index.mst', 'fakeprefix', fakeConfig)
+    expect(uploadMock).toHaveBeenCalledWith(expect.objectContaining({ Key: 'fakeprefix/index.xyz' }))
+    expect(uploadParams.ContentType).toBeUndefined()
   })
 
   test('uploadDir should call S3#upload one time per file', async () => {


### PR DESCRIPTION
## Description
- Not uploading unknown files to s3
- Set default cache control for unknown files


## Related Issue
Fix: #134 

## Motivation and Context

Handle cases where `mime-type` lib returns false for unknown files 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
