### PR TITLE
Changes required for aio stage deployment

### DIFF
--- a/lib/remote-storage.js
+++ b/lib/remote-storage.js
@@ -111,7 +111,7 @@ module.exports = class RemoteStorage {
     const uploadParams = {
       Key: urlJoin(prefix, path.basename(file)),
       Body: content,
-      ACL: 'public-read',
+      /* ACL: 'public-read', */
       CacheControl: cacheControlString
     }
     // s3 misses some mime types like for css files

--- a/lib/remote-storage.js
+++ b/lib/remote-storage.js
@@ -111,7 +111,6 @@ module.exports = class RemoteStorage {
     const uploadParams = {
       Key: urlJoin(prefix, path.basename(file)),
       Body: content,
-      /* ACL: 'public-read', */
       CacheControl: cacheControlString
     }
     // s3 misses some mime types like for css files

--- a/src/deploy-web.js
+++ b/src/deploy-web.js
@@ -46,13 +46,13 @@ const deployWeb = async (config, log) => {
     await getTvmCredentials(config.ow.namespace, config.ow.auth, config.s3.tvmUrl, config.s3.credsCacheFile)
 
   const remoteStorage = new RemoteStorage(creds)
-  const exists = await remoteStorage.folderExists(config.s3.folder)
+  const exists = await remoteStorage.folderExists(config.s3.folder + '/')
 
   if (exists) {
     if (log) {
       log('warning: an existing deployment will be overwritten')
     }
-    await remoteStorage.emptyFolder(config.s3.folder)
+    await remoteStorage.emptyFolder(config.s3.folder + '/')
   }
   const _log = log ? (f) => log(`deploying ${path.relative(dist, f)}`) : null
   await remoteStorage.uploadDir(dist, config.s3.folder, config.app, _log)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The creds that TVM generates only have access to one specific folder.
So trying to list the parent folder shouldn't ideally work and that is the case for Stage.
Hence appending a slash at the end to make this work.

Also, stage bucket is not public for security reasons. Hence the ACL of `public-read` throws an `AccessDenied` error.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
