### PR TITLE
breaking: remove node-12 support

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [14.x, 16.x]
         os: [ubuntu-latest, windows-latest]
 
     steps:

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "Adobe Inc.",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=12.2.0"
+    "node": "^14.18 || ^16.13 || >=18"
   },
   "repository": "adobe/aio-lib-web",
   "homepage": "https://github.com/adobe/aio-lib-web",


### PR DESCRIPTION
## Motivation and Context

This pr bumps node support to LTS versions and drops support for 12 which is EOL
Minor version choices are to ensure we get node: namespace supporting versions of node. 

## How Has This Been Tested?

CI
note that the node-12 tests will not finish since it has been removed in the Github Action CI script

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
