### PR TITLE
export new/experimental webpack bundler

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ const buildWeb = require('./src/build-web')
 const deployWeb = require('./src/deploy-web')
 const undeployWeb = require('./src/undeploy-web')
 const bundle = require('./src/bundle')
+const bundlewp = require('./src/bundle-wp')
 
 /**
  * Adobe I/O app lib web, build / deploy webapps to cdn
@@ -31,6 +32,7 @@ const bundle = require('./src/bundle')
 
 module.exports = {
   bundle,
+  bundlewp,
   buildWeb,
   deployWeb,
   undeployWeb

--- a/package.json
+++ b/package.json
@@ -35,15 +35,17 @@
     "aws-sdk": "^2.1211.0",
     "core-js": "^3.25.1",
     "fs-extra": "^10",
+    "glob": "^8.0.3",
+    "html-webpack-plugin": "^5.5.0",
     "joi": "^17.2.1",
     "klaw": "^4",
     "lodash.clonedeep": "^4.5.0",
     "mime-types": "^2.1.24",
     "parcel": "^2.7.0",
-    "regenerator-runtime": "^0.13.7"
+    "regenerator-runtime": "^0.13.7",
+    "webpack": "^5.74.0"
   },
   "devDependencies": {
-    "@types/hapi__joi": "^17",
     "@types/jest": "^29",
     "eslint": "^8",
     "eslint-config-standard": "^17",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This is experimental.  !!!
In the process of removing our very large dependency on parceljs, the approach was to support webkit + parcel for a while.

## Related Issue
makes use of this export, and hides it behind a flag.
https://github.com/adobe/aio-cli-plugin-app/pull/610 

## Motivation and Context

parcel is big, and while we love it, it affects the install time of the cli.  parcel is our biggest dependency.

## How Has This Been Tested?

with a sample project

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
