### PR TITLE
Update to aws v3

### DIFF
--- a/lib/remote-storage.js
+++ b/lib/remote-storage.js
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const { S3Client } = require('@aws-sdk/client-s3')
+const { S3 } = require('@aws-sdk/client-s3')
 const path = require('path')
 const mime = require('mime-types')
 const fs = require('fs-extra')
@@ -50,8 +50,25 @@ module.exports = class RemoteStorage {
       params: joi.object().keys({ Bucket: joi.string().required() }).required()
     }).unknown()
       .validate(creds)
-    if (res.error) throw res.error
-    this.s3 = S3Client(creds)
+    if (res.error) {
+      throw res.error
+    }
+
+    // the TVM response could be passed as is to the v2 client constructor, but the v3 client follows a different format
+    // see https://github.com/adobe/aio-tvm/issues/85
+    const region = creds.region || 'us-east-1'
+    // note this must supports TVM + BYO use cases
+    // see https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-s3/interfaces/credentials.html
+    const credentials = {
+      accessKeyId: creds.accessKeyId,
+      secretAccessKey: creds.secretAccessKey,
+      sessionToken: creds.sessionToken,
+      expiration: creds.expiration
+    }
+    this.bucket = creds.params.Bucket
+
+    // https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-s3/classes/s3.html#constructor
+    this.s3 = new S3({ credentials, region })
   }
 
   /**
@@ -64,10 +81,12 @@ module.exports = class RemoteStorage {
       throw new Error('prefix must be a valid string')
     }
     const listParams = {
+      Bucket: this.bucket,
       Prefix: prefix
     }
-    const listedObjects = await this.s3.listObjectsV2(listParams).promise()
-    return listedObjects.Contents.length > 0
+    const listedObjects = await this.s3.listObjectsV2(listParams)
+
+    return listedObjects.KeyCount > 0
   }
 
   /**
@@ -77,19 +96,22 @@ module.exports = class RemoteStorage {
   async emptyFolder (prefix) {
     if (typeof prefix !== 'string') throw new Error('prefix must be a valid string')
     const listParams = {
+      Bucket: this.bucket,
       Prefix: prefix
     }
-    const listedObjects = await this.s3.listObjectsV2(listParams).promise()
-    if (listedObjects.Contents.length < 1) {
+    const listedObjects = await this.s3.listObjectsV2(listParams)
+
+    if (listedObjects.KeyCount < 1) {
       return
     }
     const deleteParams = {
+      Bucket: this.bucket,
       Delete: { Objects: [] }
     }
     listedObjects.Contents.forEach(({ Key }) => {
       deleteParams.Delete.Objects.push({ Key })
     })
-    await this.s3.deleteObjects(deleteParams).promise()
+    await this.s3.deleteObjects(deleteParams)
     if (listedObjects.IsTruncated) {
       await this.emptyFolder(prefix)
     }
@@ -109,6 +131,7 @@ module.exports = class RemoteStorage {
     const mimeType = mime.lookup(path.extname(file))
     const cacheControlString = this._getCacheControlConfig(mimeType, appConfig)
     const uploadParams = {
+      Bucket: this.bucket,
       Key: urlJoin(prefix, path.basename(file)),
       Body: content,
       CacheControl: cacheControlString
@@ -117,7 +140,10 @@ module.exports = class RemoteStorage {
     if (mimeType) {
       uploadParams.ContentType = mimeType
     }
-    return this.s3.upload(uploadParams).promise()
+
+    // Note: putObject is recommended for files < 100MB and has a limit of 5GB, which is ok for our use case of storing static web assets
+    // if we intend to store larger files, we should use multipart upload and https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/modules/_aws_sdk_lib_storage.html
+    return this.s3.putObject(uploadParams)
   }
 
   async walkDir (dir) {

--- a/lib/remote-storage.js
+++ b/lib/remote-storage.js
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const aws = require('aws-sdk')
+const { S3Client } = require('@aws-sdk/client-s3')
 const path = require('path')
 const mime = require('mime-types')
 const fs = require('fs-extra')
@@ -51,7 +51,7 @@ module.exports = class RemoteStorage {
     }).unknown()
       .validate(creds)
     if (res.error) throw res.error
-    this.s3 = new aws.S3(creds)
+    this.s3 = S3Client(creds)
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@adobe/aio-lib-core-config": "^3.0.0",
     "@adobe/aio-lib-core-logging": "^2.0.0",
     "@adobe/aio-lib-core-tvm": "^3.0.0",
-    "aws-sdk": "^2.1211.0",
+    "@aws-sdk/client-s3": "^3.276.0",
     "core-js": "^3.25.1",
     "fs-extra": "^10",
     "joi": "^17.2.1",

--- a/test/jest.setup.js
+++ b/test/jest.setup.js
@@ -155,6 +155,12 @@ global.fakeTVMResponse = {
   params: { Bucket: global.fakeS3Bucket }
 }
 
+global.fakeBYOCredentials = {
+  accessKeyId: 'fake',
+  secretAccessKey: 'fake',
+  params: { Bucket: global.fakeS3Bucket }
+}
+
 global.expectedScripts = expect.objectContaining({
   buildUI: expect.any(Function),
   deployUI: expect.any(Function),

--- a/test/lib/remote-storage.test.js
+++ b/test/lib/remote-storage.test.js
@@ -10,36 +10,26 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+const mockS3 = {
+  listObjectsV2: jest.fn(),
+  deleteObjects: jest.fn(),
+  putObject: jest.fn()
+}
+
+jest.mock('@aws-sdk/client-s3', () => Object({ S3: jest.fn(() => { return mockS3 }) }))
+
+const { S3 } = require('@aws-sdk/client-s3')
 const { vol } = global.mockFs()
 
 const RemoteStorage = require('../../lib/remote-storage')
 
-const mockS3 = {
-  listObjectsV2: jest.fn(),
-  deleteObjects: jest.fn(),
-  upload: jest.fn()
-}
-
-jest.mock('@aws-sdk/client-s3', () => Object({
-  S3Client: () => mockS3
-}))
-
-function mockS3Function (name, mockedResolvedValue) {
-  let mockPromise
-  // if mockedResolveValue is a function
-  if (typeof mockedResolvedValue === 'function') {
-    mockPromise = jest.fn().mockImplementation(mockedResolvedValue)
-  } else {
-    mockPromise = jest.fn().mockResolvedValueOnce(mockedResolvedValue)
-  }
-  mockS3[name].mockReturnValue({ promise: mockPromise })
-  return { mockFn: mockS3[name], mockPromise } // might be useful to check if the promise function was called.
-}
-
 describe('RemoteStorage', () => {
   beforeEach(() => {
-    // resets all mock s3 functions
-    jest.resetAllMocks()
+    // resets all mock s3 functions, do not use jest.resetAllMocks() as it also resets the s3 client constructor mock
+    mockS3.listObjectsV2.mockReset()
+    mockS3.deleteObjects.mockReset()
+    mockS3.putObject.mockReset()
+    S3.mockClear()
     // resets the mock fs
     global.cleanFs(vol)
   })
@@ -47,6 +37,32 @@ describe('RemoteStorage', () => {
   test('Constructor should throw when missing credentials', async () => {
     const instantiate = () => new RemoteStorage({})
     expect(instantiate.bind(this)).toThrowWithMessageContaining(['required'])
+  })
+
+  test('Constructor initializes the S3 constructor properly using tvm credentials', async () => {
+    const rs = new RemoteStorage(global.fakeTVMResponse)
+    expect(S3).toHaveBeenCalledWith({
+      credentials: {
+        accessKeyId: global.fakeTVMResponse.accessKeyId,
+        secretAccessKey: global.fakeTVMResponse.secretAccessKey,
+        sessionToken: global.fakeTVMResponse.sessionToken,
+        expiration: global.fakeTVMResponse.expiration
+      },
+      region: 'us-east-1'
+    })
+    rs.bucket = global.fakeTVMResponse.Bucket
+  })
+
+  test('Constructor initializes the S3 constructor properly using byo credentials', async () => {
+    const rs = new RemoteStorage(global.fakeBYOCredentials)
+    expect(S3).toHaveBeenCalledWith({
+      credentials: {
+        accessKeyId: global.fakeTVMResponse.accessKeyId,
+        secretAccessKey: global.fakeTVMResponse.secretAccessKey
+      },
+      region: 'us-east-1'
+    })
+    rs.bucket = global.fakeTVMResponse.Bucket
   })
 
   test('folderExists missing prefix', async () => {
@@ -70,108 +86,99 @@ describe('RemoteStorage', () => {
   })
 
   test('folderExists should return false if there are no files', async () => {
-    const { mockFn } = mockS3Function('listObjectsV2', { Contents: [] })
+    mockS3.listObjectsV2.mockResolvedValue({ KeyCount: 0 })
     const rs = new RemoteStorage(global.fakeTVMResponse)
     expect((await rs.folderExists('fakeprefix'))).toBe(false)
-    expect(mockFn).toHaveBeenCalledWith({ Prefix: 'fakeprefix' })
+    expect(mockS3.listObjectsV2).toHaveBeenCalledWith({ Bucket: 'fake-bucket', Prefix: 'fakeprefix' })
   })
 
   test('folderExists should return true if there are files', async () => {
-    mockS3Function('listObjectsV2', { Contents: ['fakeprefix/index.html'] })
+    mockS3.listObjectsV2.mockResolvedValue({ KeyCount: 1 })
     const rs = new RemoteStorage(global.fakeTVMResponse)
     expect((await rs.folderExists('fakeprefix'))).toBe(true)
   })
 
   test('emptyFolder should not throw if there are no files', async () => {
-    mockS3Function('listObjectsV2', { Contents: [] })
+    mockS3.listObjectsV2.mockResolvedValue({ KeyCount: 0 })
     const rs = new RemoteStorage(global.fakeTVMResponse)
     expect(rs.emptyFolder.bind(rs, 'fakeprefix')).not.toThrow()
   })
 
   test('emptyFolder should not call S3#deleteObjects if already empty', async () => {
-    mockS3Function('listObjectsV2', { Contents: [] })
-    const { mockFn: mockDelete } = mockS3Function('deleteObjects', {})
+    mockS3.listObjectsV2.mockResolvedValue({ KeyCount: 0 })
     const rs = new RemoteStorage(global.fakeTVMResponse)
     await rs.emptyFolder('fakeprefix')
-    expect(mockDelete).toHaveBeenCalledTimes(0)
+    expect(mockS3.deleteObjects).toHaveBeenCalledTimes(0)
   })
 
   test('emptyFolder should call S3#deleteObjects with correct parameters with one file', async () => {
     const content = [{ Key: 'fakeprefix/index.html' }]
-    mockS3Function('listObjectsV2', { Contents: content })
-    const { mockFn: mockDelete } = mockS3Function('deleteObjects', {})
+    mockS3.listObjectsV2.mockResolvedValue({ KeyCount: 1, Contents: content })
     const rs = new RemoteStorage(global.fakeTVMResponse)
     await rs.emptyFolder('fakeprefix')
-    expect(mockDelete).toHaveBeenCalledWith({ Delete: { Objects: content } })
+    expect(mockS3.deleteObjects).toHaveBeenCalledWith({ Bucket: 'fake-bucket', Delete: { Objects: content } })
   })
 
   test('emptyFolder should call S3#deleteObjects with correct parameters with multiple files', async () => {
     const content = [{ Key: 'fakeprefix/index.html' }, { Key: 'fakeprefix/index.css' }, { Key: 'fakeprefix/index.css' }]
-    mockS3Function('listObjectsV2', { Contents: content })
-    const { mockFn: mockDelete } = mockS3Function('deleteObjects', {})
+    mockS3.listObjectsV2.mockResolvedValue({ KeyCount: 3, Contents: content })
     const rs = new RemoteStorage(global.fakeTVMResponse)
     await rs.emptyFolder('fakeprefix')
-    expect(mockDelete).toHaveBeenCalledWith({ Delete: { Objects: content } })
+    expect(mockS3.deleteObjects).toHaveBeenCalledWith({ Bucket: 'fake-bucket', Delete: { Objects: content } })
   })
 
   test('emptyFolder should call S3#deleteObjects multiple time if listObjects is truncated', async () => {
     const content = [{ Key: 'fakeprefix/index.html' }, { Key: 'fakeprefix/index.css' }, { Key: 'fakeprefix/index.js' }]
     let iterations = 2
-    mockS3Function('listObjectsV2', () => {
+    mockS3.listObjectsV2.mockImplementation(() => {
       const res = { Contents: [content[iterations]], IsTruncated: iterations > 0 }
       iterations--
-      return res
+      return Promise.resolve(res)
     })
-    const { mockFn: mockDelete } = mockS3Function('deleteObjects', {})
     const rs = new RemoteStorage(global.fakeTVMResponse)
     await rs.emptyFolder('fakeprefix')
-    expect(mockDelete).toHaveBeenCalledWith({ Delete: { Objects: [content[0]] } })
-    expect(mockDelete).toHaveBeenCalledWith({ Delete: { Objects: [content[1]] } })
-    expect(mockDelete).toHaveBeenCalledWith({ Delete: { Objects: [content[2]] } })
+    expect(mockS3.deleteObjects).toHaveBeenCalledWith({ Bucket: 'fake-bucket', Delete: { Objects: [content[0]] } })
+    expect(mockS3.deleteObjects).toHaveBeenCalledWith({ Bucket: 'fake-bucket', Delete: { Objects: [content[1]] } })
+    expect(mockS3.deleteObjects).toHaveBeenCalledWith({ Bucket: 'fake-bucket', Delete: { Objects: [content[2]] } })
   })
 
   test('uploadFile should call S3#upload with the correct parameters', async () => {
     global.addFakeFiles(vol, 'fakeDir', { 'index.js': 'fake content' })
-    const { mockFn: mockUpload } = mockS3Function('upload', {})
     const rs = new RemoteStorage(global.fakeTVMResponse)
     const fakeConfig = {}
     await rs.uploadFile('fakeDir/index.js', 'fakeprefix', fakeConfig)
     const body = Buffer.from('fake content', 'utf8')
-    expect(mockUpload).toHaveBeenCalledWith(expect.objectContaining({ Key: 'fakeprefix/index.js', Body: body, ContentType: 'application/javascript' }))
+    expect(mockS3.putObject).toHaveBeenCalledWith(expect.objectContaining({ Bucket: 'fake-bucket', Key: 'fakeprefix/index.js', Body: body, ContentType: 'application/javascript' }))
   })
 
   test('uploadFile should call S3#upload with the correct parameters and slash-prefix', async () => {
     global.addFakeFiles(vol, 'fakeDir', { 'index.js': 'fake content' })
-    const { mockFn: mockUpload } = mockS3Function('upload', {})
     const rs = new RemoteStorage(global.fakeTVMResponse)
     const fakeConfig = {}
     await rs.uploadFile('fakeDir/index.js', '/slash-prefix', fakeConfig)
     const body = Buffer.from('fake content', 'utf8')
-    expect(mockUpload).toHaveBeenCalledWith(expect.objectContaining({ Key: '/slash-prefix/index.js', Body: body, ContentType: 'application/javascript' }))
+    expect(mockS3.putObject).toHaveBeenCalledWith(expect.objectContaining({ Bucket: 'fake-bucket', Key: '/slash-prefix/index.js', Body: body, ContentType: 'application/javascript' }))
   })
 
   test('uploadFile S3#upload with an unknown Content-Type', async () => {
     global.addFakeFiles(vol, 'fakeDir', { 'index.mst': 'fake content' })
-    const { mockFn: mockUpload } = mockS3Function('upload', {})
     const rs = new RemoteStorage(global.fakeTVMResponse)
     const fakeConfig = {}
     await rs.uploadFile('fakeDir/index.mst', 'fakeprefix', fakeConfig)
     const body = Buffer.from('fake content', 'utf8')
-    expect(mockUpload).toHaveBeenCalledWith(expect.objectContaining({ Key: 'fakeprefix/index.mst', Body: body }))
-    expect(mockUpload.mock.calls[0][0]).not.toHaveProperty('ContentType')
+    expect(mockS3.putObject).toHaveBeenCalledWith(expect.objectContaining({ Bucket: 'fake-bucket', Key: 'fakeprefix/index.mst', Body: body }))
+    expect(mockS3.putObject.mock.calls[0][0]).not.toHaveProperty('ContentType')
   })
 
   test('uploadDir should call S3#upload one time per file', async () => {
     await global.addFakeFiles(vol, 'fakeDir', ['index.js', 'index.css', 'index.html'])
-    const { mockFn: mockUpload } = mockS3Function('upload', {})
     const rs = new RemoteStorage(global.fakeTVMResponse)
     await rs.uploadDir('fakeDir', 'fakeprefix', global.fakeConfig.creds.cna)
-    expect(mockUpload).toHaveBeenCalledTimes(3)
+    expect(mockS3.putObject).toHaveBeenCalledTimes(3)
   })
 
   test('uploadDir should call a callback once per uploaded file', async () => {
     await global.addFakeFiles(vol, 'fakeDir', ['index.js', 'index.css', 'index.html', 'test/i.js'])
-    mockS3Function('upload', {})
     const cbMock = jest.fn()
     const rs = new RemoteStorage(global.fakeTVMResponse)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR updates the S3 SDK to v3 from v2. 

The usage of v2 shows an ugly warning when deploying assets:
```
aio app deploy
⠋ Updating log forwarding configuration(node:10089) NOTE: The AWS SDK for JavaScript (v2) will be put into maintenance mode in 2023.

Please migrate your code to use AWS SDK for JavaScript (v3).
For more information, check the migration guide at https://a.co/7PzMCcy
(Use `node --trace-warnings ...` to show where the warning was created)
✔ Built 2 action(s) for 'dx/excshell/1'
✔ Building web assets for 'dx/excshell/1'
✔ Deployed 4 action(s) for 'dx/excshell/1'
✔ Deploying web assets for 'dx/excshell/1'
```

Another reason to update is that v3 takes a modular approach and will help us reduce CLI dependencies size by a good amount, see: https://github.com/adobe/aio-cli/issues/349

## Tests

This has been tested with:
- unit tests
- linking aio cli and running `aio app deploy --skip-actions`
- linking aio cli and running `aio app undeploy --skip-actions`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
