### PR TITLE
fix: codecov not using GH Action

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -31,7 +31,6 @@ jobs:
     - run: npm test
     - name: upload coverage
       if: success()
-      run: curl -s https://codecov.io/bash | bash
-      env:
-        CODECOV_NAME: ${{ runner.os }} node.js ${{ matrix.node-version }}
-      shell: bash
+      uses: codecov/codecov-action@v3.1.1
+      with:
+        name: ${{ runner.os }} node.js ${{ matrix.node-version }}


### PR DESCRIPTION
## Motivation and Context

Codecov checks were not run because it was using an obsolete method (bash script).

## How Has This Been Tested?

This is the test

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
