### PR TITLE
fix: access denied during undeploy

### DIFF
--- a/src/undeploy-web.js
+++ b/src/undeploy-web.js
@@ -22,11 +22,11 @@ const undeployWeb = async (config) => {
 
   const remoteStorage = new RemoteStorage(creds)
 
-  if (!(await remoteStorage.folderExists(config.s3.folder))) {
+  if (!(await remoteStorage.folderExists(config.s3.folder + '/'))) {
     throw new Error(`cannot undeploy static files, there is no deployment for ${config.s3.folder}`)
   }
 
-  await remoteStorage.emptyFolder(config.s3.folder)
+  await remoteStorage.emptyFolder(config.s3.folder + '/')
 }
 
 module.exports = undeployWeb

--- a/test/src/undeploy-web.test.js
+++ b/test/src/undeploy-web.test.js
@@ -64,8 +64,8 @@ describe('undeploy-web', () => {
     await undeployWeb(config)
     expect(getS3Credentials).toHaveBeenCalledWith(config)
     expect(RemoteStorage).toHaveBeenCalledWith('fakecreds')
-    expect(mockRemoteStorageInstance.folderExists).toHaveBeenCalledWith('somefolder')
-    expect(mockRemoteStorageInstance.emptyFolder).toHaveBeenCalledWith('somefolder')
+    expect(mockRemoteStorageInstance.folderExists).toHaveBeenCalledWith('somefolder/')
+    expect(mockRemoteStorageInstance.emptyFolder).toHaveBeenCalledWith('somefolder/')
   })
 
   test('throws if remoteStorage folder does not exist', async () => {
@@ -89,7 +89,7 @@ describe('undeploy-web', () => {
     await expect(undeployWeb(config)).rejects.toThrow('cannot undeploy static files')
     expect(getS3Credentials).toHaveBeenCalledWith(config)
     expect(RemoteStorage).toHaveBeenCalledWith('fakecreds')
-    expect(mockRemoteStorageInstance.folderExists).toHaveBeenCalledWith('somefolder')
+    expect(mockRemoteStorageInstance.folderExists).toHaveBeenCalledWith('somefolder/')
     expect(mockRemoteStorageInstance.emptyFolder).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Description

When running `AIO_CLI_ENV=stage aio app undeploy` the following error was being returned: 

```
➜  color-web-app-excshell git:(main) ✗ AIO_CLI_ENV=stage aio app undeploy
✖ Un-Deploying web assets for dx/excshell/1
 ›   Error: Access Denied
```

Adding a slash to the end of the S3 path fixes this issue because the code is attempting to list objects in a folder and it seems S3 deems anything not ending with a slash as a file, which is invalid 

Note: We are not seeing this in production because the prod bucket has public access enabled (😨)

## Motivation and Context

To fix `aio app undeploy` in stage

## How Has This Been Tested?

Locally linked aio-lib-web, `npm run test`

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
