### PR TITLE
fix: pin @aws-sdk/client-s3 to v3.623.0 to fix `identity.expiration.getTime is not a function` issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@adobe/aio-lib-core-config": "^5",
     "@adobe/aio-lib-core-logging": "^3",
     "@adobe/aio-lib-core-tvm": "^4",
-    "@aws-sdk/client-s3": "^3.276.0",
+    "@aws-sdk/client-s3": "3.623.0",
     "core-js": "^3.25.1",
     "fs-extra": "^11",
     "joi": "^17.2.1",


### PR DESCRIPTION
see #200

## How Has This Been Tested?

- npm run e2e


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
