### PR TITLE
batch 50 files for upload

### DIFF
--- a/lib/remote-storage.js
+++ b/lib/remote-storage.js
@@ -245,21 +245,31 @@ module.exports = class RemoteStorage {
     // walk the whole directory recursively using klaw.
     const files = await this.walkDir(dir)
 
-    // parallel upload
-    return Promise.all(files.map(async f => {
-      // get file's relative folder to the base directory.
-      let prefixDirectory = path.dirname(path.relative(dir, f))
-      // base directory returns ".", ignore that.
-      prefixDirectory = prefixDirectory === '.' ? '' : prefixDirectory
-      // newPrefix is now the initial prefix plus the files relative directory path.
-      const newPrefix = urlJoin(prefix, prefixDirectory)
-      const s3Res = await this.uploadFile(f, newPrefix, appConfig, dir)
-
-      if (postFileUploadCallback) {
-        postFileUploadCallback(f)
-      }
-      return s3Res
-    }))
+    // we will upload files in batches of 50 to prevent warnings about enqued tasks.
+    // this happens based on the default maxSockets value of 50 in node.js but we cannot change
+    // the user's default value.
+    // less than 1% of users will see this warning, but it is better to prevent it.
+    const batchSize = 50
+    let fileBatch = files.splice(0, batchSize)
+    const allResults = []
+    while (fileBatch.length > 0) {
+      const res = await Promise.all(fileBatch.map(async f => {
+        // get file's relative folder to the base directory.
+        let prefixDirectory = path.dirname(path.relative(dir, f))
+        // base directory returns ".", ignore that.
+        prefixDirectory = prefixDirectory === '.' ? '' : prefixDirectory
+        // newPrefix is now the initial prefix plus the files relative directory path.
+        const newPrefix = urlJoin(prefix, prefixDirectory)
+        const s3Res = await this.uploadFile(f, newPrefix, appConfig, dir)
+        if (postFileUploadCallback) {
+          postFileUploadCallback(f)
+        }
+        return s3Res
+      }))
+      allResults.push(res)
+      fileBatch = files.splice(0, batchSize)
+    }
+    return allResults
   }
 
   /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Upload files in batches of 50 to prevent warnings about enqued tasks.
This happens based on the default maxSockets value of 50 in node.js but we cannot change the user's default value.

Less than 1% of users will see this warning, but it is better to prevent it.


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
