### PR TITLE
bump aws-sdk/client-s3 to 3.1045.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@adobe/aio-lib-core-config": "^5",
     "@adobe/aio-lib-core-logging": "^3",
     "@adobe/aio-lib-core-tvm": "^4",
-    "@aws-sdk/client-s3": "^3.624.0",
+    "@aws-sdk/client-s3": "^3.1045.0",
     "@smithy/node-http-handler": "^4.0.2",
     "core-js": "^3.25.1",
     "fs-extra": "^11",


### PR DESCRIPTION
Resolves critical CVE-2026-25128 (GHSA-37qj-frw5-hhjh) — a RangeError DoS via malformed numeric entities in fast-xml-parser, affecting versions < 5.3.4.

## Description

Bumps `@aws-sdk/client-s3` to `3.1045.0`, which transitively pulls in `@aws-sdk/xml-builder@3.972.22` → `fast-xml-parser@5.7.2`, resolving the critical vulnerability present in the previously pinned `fast-xml-parser@5.2.5`.

## Related Issue

Resolves CVE-2026-25128 / [GHSA-37qj-frw5-hhjh](https://github.com/advisories/GHSA-37qj-frw5-hhjh)

## Motivation and Context

`fast-xml-parser@5.2.5` (pulled in via `@aws-sdk/xml-builder@3.965.0`) contains a critical RangeError Denial-of-Service vulnerability triggered by malformed numeric entities in XML input. An attacker able to supply crafted XML payloads could crash the Node.js process. Upgrading `@aws-sdk/client-s3` to `3.1045.0` resolves the full vulnerability chain.

**Dependency chain before:**
```
@aws-sdk/client-s3 → @aws-sdk/xml-builder@3.965.0 → fast-xml-parser@5.2.5 ❌
```

**Dependency chain after:**
```
@aws-sdk/client-s3@3.1045.0 → @aws-sdk/xml-builder@3.972.22 → fast-xml-parser@5.7.2 ✅
```

## How Has This Been Tested?

- Verified the resolved dependency tree via `npm install --dry-run` confirming `fast-xml-parser@5.7.2` is installed.
- Confirmed `@aws-sdk/xml-builder@3.972.22` ships `fast-xml-parser@5.7.2` via `npm info`.
- Existing test suite passed with no regressions.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
